### PR TITLE
Support for persistence

### DIFF
--- a/Cureos.Measures.Tests/Cureos.Measures.Tests.csproj
+++ b/Cureos.Measures.Tests/Cureos.Measures.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Linq\ConversionsTests.cs" />
     <Compile Include="Linq\StandardMeasureEnumerableTests.cs" />
     <Compile Include="MeasureAssert.cs" />
+    <Compile Include="MeasureCreationTests.cs" />
     <Compile Include="MeasureTests.cs" />
     <Compile Include="PrimeNumbersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -63,6 +64,7 @@
     <Compile Include="StandardMeasureTests.cs" />
     <Compile Include="StandardMeasureTripletTests.cs" />
     <Compile Include="TimingTests.cs" />
+    <Compile Include="UnitParsingTests.cs" />
     <Compile Include="UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Cureos.Measures.Tests/MeasureCreationTests.cs
+++ b/Cureos.Measures.Tests/MeasureCreationTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Cureos.Measures.Quantities;
+using NUnit.Framework;
+
+namespace Cureos.Measures
+{
+	[TestFixture]
+	public class MeasureCreationTests
+	{
+		[Test]
+		public void NonGenericFrom_ExistingUnit_Measure()
+		{
+			IMeasure tenFeet = Measure.From(10d, "ft");
+
+			Assert.That(tenFeet, Is.EqualTo(new Measure<Length>(10d, Length.Foot)));
+		}
+
+		[Test]
+		public void NonGenericFrom_MissingUnit_Exception()
+		{
+			Assert.That(()=> Measure.From(10d, "non-existing"),
+				Throws.InstanceOf<UnitNotFoundException>());
+		}
+
+		[Test]
+		public void GenericFrom_ExistingUnit_Measure()
+		{
+			IMeasure<Length> tenFeet = Measure.From<Length>(10d, "ft");
+
+			Assert.That(tenFeet, Is.EqualTo(new Measure<Length>(10d, Length.Foot)));
+		}
+
+		[Test]
+		public void GenericFrom_MissingUnit_Exception()
+		{
+			Assert.That(() => Measure.From<Length>(10d, "non-existing"),
+				Throws.InstanceOf<UnitNotFoundException>());
+		}
+
+		[Test]
+		public void GenericFrom_IncorrectQuantity_RuntimeException()
+		{
+			Assert.That(() => Measure.From<Time>(10d, "cm"),
+				Throws.InstanceOf<InvalidCastException>());
+		}
+	}
+}

--- a/Cureos.Measures.Tests/UnitParsingTests.cs
+++ b/Cureos.Measures.Tests/UnitParsingTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Cureos.Measures.Quantities;
+using NUnit.Framework;
+
+namespace Cureos.Measures
+{
+	[TestFixture]
+	public class UnitParsingTests
+	{
+		[Test]
+		public void NonGenericParse_ExistingUnit_UnitReturned()
+		{
+			IUnit cm = Unit.Parse("cm");
+
+			Assert.That(cm, Is.SameAs(Length.CentiMeter));
+		}
+
+		[Test]
+		public void NonGenericParse_WrongCase_UnitReturned()
+		{
+			IUnit CM = Unit.Parse("CM");
+
+			Assert.That(CM, Is.SameAs(Length.CentiMeter));
+		}
+
+		[Test]
+		public void NonGenericParse_NonExistingUnit_Exception()
+		{
+			Assert.That(() => Unit.Parse("non-existing"),
+				Throws.InstanceOf<UnitNotFoundException>()
+					.With.Message.StringContaining("non-existing"));
+		}
+
+		[Test]
+		public void GenericParse_ExistingUnitWithCorrectQuantity_UnitReturned()
+		{
+			IUnit<Length> cm = Unit.Parse<Length>("cm");
+
+			Assert.That(cm, Is.SameAs(Length.CentiMeter));
+		}
+
+		[Test]
+		public void GenericParse_WrongCase_UnitReturned()
+		{
+			IUnit<Length> CM = Unit.Parse<Length>("CM");
+
+			Assert.That(CM, Is.SameAs(Length.CentiMeter));
+		}
+
+		[Test]
+		public void GenericParse_NonExistingUnit_Exception()
+		{
+			Assert.That(() => Unit.Parse<Length>("non-existing"),
+				Throws.InstanceOf<UnitNotFoundException>()
+					.With.Message.StringContaining("non-existing"));
+		}
+
+		[Test]
+		public void GenericParse_IncorrectQuantity_RuntimeException()
+		{
+			Assert.That(() => Unit.Parse<Time>("cm"),
+				Throws.InstanceOf<InvalidCastException>());
+		}
+	}
+}

--- a/Cureos.Measures/Cureos.Measures.csproj
+++ b/Cureos.Measures/Cureos.Measures.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Linq\Conversions.cs" />
     <Compile Include="Linq\StandardMeasureEnumerable.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Measure.Creation.cs" />
     <Compile Include="Measure.cs" />
     <Compile Include="PrimeNumbers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -114,6 +115,8 @@
     <Compile Include="StandardMeasureDoublet.cs" />
     <Compile Include="StandardMeasureTriplet.cs" />
     <Compile Include="Unit.cs" />
+    <Compile Include="Unit.Parsing.cs" />
+    <Compile Include="UnitNotFoundException.cs" />
     <Compile Include="UnitPrefix.cs" />
     <Compile Include="UnitPrefixMethods.cs" />
   </ItemGroup>

--- a/Cureos.Measures/Measure.Creation.cs
+++ b/Cureos.Measures/Measure.Creation.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Cureos.Measures
+{
+	public class Measure
+	{
+		private static readonly IDictionary<IUnit, Func<double, IUnit, IMeasure>> _creationsByUnit;
+		static Measure()
+		{
+			_creationsByUnit = QuantityCollection.Quantities
+				.SelectMany(qa => qa.Units)
+				.ToDictionary(u => u, generate);
+		}
+
+		private static Func<double, IUnit, IMeasure> generate(IUnit unit)
+		{
+			Type measure = typeof(Measure<>).MakeGenericType(unit.Quantity.GetType());
+
+			// would like to generate delegate from expression, but WinPho does not support .Compile()
+			// .Create instance is not the fastest way to create instances
+			return (a, u) => (IMeasure)Activator.CreateInstance(measure, a, u);
+			
+			/* 
+			Type unitType = unit.GetType();
+			ConstructorInfo ctor = measure
+				.GetConstructor(new[] { typeof(double), unitType });
+			
+			ParameterExpression
+				param1 = Expression.Parameter(typeof(double), "arg1"),
+				param2 = Expression.Parameter(unitType, "arg2");
+
+			return Expression.Lambda(
+				Expression.New(ctor, param1, param2), param1, param2)
+				.Compile();
+			 */
+
+		}
+
+		public static IMeasure From(double amount, string unit)
+		{
+			IUnit parsed = Unit.Parse(unit);
+
+			Func<double, IUnit, IMeasure> creation = _creationsByUnit[parsed];
+
+			return creation(amount, parsed);
+		}
+
+		public static IMeasure<Q> From<Q>(double amount, string unit) where Q : struct, IQuantity<Q>
+		{
+			IUnit parsed = Unit.Parse(unit);
+
+			Func<double, IUnit, IMeasure> creation = _creationsByUnit[parsed];
+
+			IMeasure created = creation(amount, parsed);
+
+			return (IMeasure<Q>) created;
+		}
+	}
+}

--- a/Cureos.Measures/Unit.Parsing.cs
+++ b/Cureos.Measures/Unit.Parsing.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cureos.Measures
+{
+	public class Unit
+	{
+		private static readonly IDictionary<string, IUnit> _unitsBySymbol;
+
+		class UnitSymbolComparer : IEqualityComparer<IUnit>
+		{
+			public bool Equals(IUnit x, IUnit y)
+			{
+				return StringComparer.OrdinalIgnoreCase.Equals(x.Symbol, y.Symbol);
+			}
+
+			public int GetHashCode(IUnit obj)
+			{
+				return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Symbol);
+			}
+		}
+
+		static Unit()
+		{
+			_unitsBySymbol = QuantityCollection.Quantities
+				.SelectMany(qa => qa.Units)
+				.Distinct(new UnitSymbolComparer())
+				.ToDictionary(u => u.Symbol, u => u, StringComparer.OrdinalIgnoreCase);
+		}
+
+		public static IUnit Parse(string s)
+		{
+			try
+			{
+				return _unitsBySymbol[s];
+			}
+			catch (KeyNotFoundException)
+			{
+				throw UnitNotFoundException.Default(s, "s");
+			}
+		}
+
+		public static bool TryParse(string s, out IUnit unit)
+		{
+			return _unitsBySymbol.TryGetValue(s, out unit);
+		}
+
+		public static IUnit<Q> Parse<Q>(string s) where Q : struct, IQuantity<Q>
+		{
+			IUnit parsed = Parse(s);
+			return (IUnit<Q>)parsed;
+		}
+	}
+}

--- a/Cureos.Measures/UnitNotFoundException.cs
+++ b/Cureos.Measures/UnitNotFoundException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Cureos.Measures
+{
+	//[System.Serializable]
+	public class UnitNotFoundException : ArgumentException
+	{
+		public UnitNotFoundException() {}
+		public UnitNotFoundException(string message) : base(message) {}
+		public UnitNotFoundException(string message, string paramName) : base(message, paramName) {}
+		public UnitNotFoundException(string message, Exception inner) : base(message, inner) {}
+		//protected UnitNotFoundException(System.Runtime.Serialization.SerializationInfo info, StreamingContext context) : base(info, context) {}
+
+		public static UnitNotFoundException Default(string toBeParsed, string paramName)
+		{
+			string message = string.Format("Unit '{0}' could not be parsed.", toBeParsed);
+			return new UnitNotFoundException(message, paramName);
+		}
+	}
+}


### PR DESCRIPTION
Measures are great runtime-wise, but when it comes to persist/serialize one measure, it can get ugly.
I was thinking of storing the amount as a double and the unit as a string, so when we re-hydrate that persisted measure we need a way to get unit from its string representation.
Generics get in the way big time and we have to resort to perform runtime casting to transform an IUnit into the IUnit<Q>.
Likewise, when getting a IMeasure<Q> we need to cast the created IMeasure to its generic type.

Besides, I only modified the portable project as I am not very familiar with that way of working. But the WinPho and WinRT already pose challenges (lack of serialization and ability to compile expressions, mainly).

Please, let me know what you think, and feel free to suggest further changes, using the pull request.

Thanks for a great library